### PR TITLE
feat: add bootstrap kustomize

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -142,7 +142,7 @@ We will start by creating the configs required by Talos:
 Run the following:
 
 ```bash
-$ osctl config generate example-0 https://192.168.1.101:6443 -o ./clusters/metal/generate
+$ talosctl gen config example-0 https://192.168.1.101:6443 -o ./clusters/metal/generate
 generating PKI and tokens
 created clusters/metal/generate/init.yaml
 created clusters/metal/generate/controlplane.yaml
@@ -150,10 +150,10 @@ created clusters/metal/generate/join.yaml
 created clusters/metal/generate/talosconfig
 ```
 
-Configure `osctl`:
+Configure `talosctl`:
 
 ```bash
-osctl --talosconfig clusters/metal/generate/talosconfig config endpoint 192.168.1.101
+talosctl --talosconfig clusters/metal/generate/talosconfig config endpoint 192.168.1.101
 ```
 
 Make any edits the Talos configs now.

--- a/examples/bootstrap/host_network_patch.yaml
+++ b/examples/bootstrap/host_network_patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/hostNetwork
+  value: true

--- a/examples/bootstrap/kustomization.yaml
+++ b/examples/bootstrap/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../mgmt
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: metal-controller-manager
+      namespace: arges-system
+    path: host_network_patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: metal-metadata-server
+      namespace: arges-system
+    path: host_network_patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: metal-metadata-server
+      namespace: arges-system
+    path: metadata_patch.yaml

--- a/examples/bootstrap/metadata_patch.yaml
+++ b/examples/bootstrap/metadata_patch.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: "/spec/template/spec/containers/0/args"
+  create: true
+  value:
+    - "--port=9091"
+
+- op: replace
+  path: "/spec/template/spec/containers/0/ports"
+  value:
+    - containerPort: 9091
+      name: http
+      protocol: TCP


### PR DESCRIPTION
This PR will update the README to use talosctl instead of osctl.
Additionally, it will add some very basic kustomize patches that will be
used for running the components on a "bootstrap" docker-based Talos
cluster to get the management plane up and running.