### PR TITLE
chore: update metal-controller-manager version

### DIFF
--- a/config/bases/metal-controller-manager/kustomization.yaml
+++ b/config/bases/metal-controller-manager/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: controller
     newName: docker.io/autonomy/metal-controller-manager
-    newTag: db197c7
+    newTag: c2bd528


### PR DESCRIPTION
This PR will pull in a newer version of metal-controller-manager that
will use talos v0.4.1 as a base for the discovery image's kernel.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>