### PR TITLE
chore: update metal-controller-manager version

### DIFF
--- a/config/bases/metal-controller-manager/kustomization.yaml
+++ b/config/bases/metal-controller-manager/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: controller
     newName: docker.io/autonomy/metal-controller-manager
-    newTag: b49a671
+    newTag: 52d0384

--- a/config/bases/metal-controller-manager/kustomization.yaml
+++ b/config/bases/metal-controller-manager/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: controller
     newName: docker.io/autonomy/metal-controller-manager
-    newTag: 52d0384
+    newTag: 0347d01

--- a/config/bases/metal-metadata-server/kustomization.yaml
+++ b/config/bases/metal-metadata-server/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: server
     newName: docker.io/autonomy/metal-metadata-server
-    newTag: a07d1ff
+    newTag: 959cc7b


### PR DESCRIPTION
This PR will pull in the newer version of metal controller manager that
supports server classes and BMC info at the server resource level