### PR TITLE
chore: bump metadata server image

### DIFF
--- a/config/bases/metal-metadata-server/kustomization.yaml
+++ b/config/bases/metal-metadata-server/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: server
     newName: docker.io/autonomy/metal-metadata-server
-    newTag: 959cc7b
+    newTag: 72d6ac2


### PR DESCRIPTION
This will pull in the metadata server that supports kubelet node
labeling.