### PR TITLE
chore: update metal-controller-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/clusters/metal/machines.yaml
 !examples/clusters/metal/generate/.gitkeep
 examples/mgmt/discovery_kubeconfig_patch.yaml
 examples/mgmt/default_environment_patch.yaml
+examples/bootstrap/api_endpoint.yaml

--- a/config/bases/metal-controller-manager/kustomization.yaml
+++ b/config/bases/metal-controller-manager/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: controller
     newName: docker.io/autonomy/metal-controller-manager
-    newTag: 0347d01
+    newTag: c5cf0dc

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,18 +21,6 @@ To get started with Arges, we need to know a few bits of information beforehand.
 Determining this information is dependent on how you choose to expose the Arges `metal-ipxe`, `metal-metadata-server`, and `metal-tftp` services.
 However you choose to expose these services, we simply need to know the endpoint for each.
 
-Once you determine these, and you have the discovery `kubeconfig` available over http, export the endpoints for the `metal-metadata-server` service and discovery `kubeconfig` endpoint:
-
-```bash
-cat <<EOF >mgmt/discovery_kubeconfig_patch.yaml
-- op: add
-  path: /spec/template/spec/containers/1/args/-
-  value: --discovery-kubeconfig=${DISCOVERY_KUBECONFIG_ENDPOINT}
-EOF
-```
-
-> Note: `DISCOVERY_KUBECONFIG_ENDPOINT` should include the scheme (e.g. http or https).
-
 We will also create a dummy patch file to satisfy a requirement from kustomize.
 This patch will be updated later.
 
@@ -135,7 +123,6 @@ To register machines, simply power them on.
 The machines should do a number of things:
 
 - boot using the deployed TFTP, and iPXE services in Arges
-- download the discovery `kubeconfig`
 - create a custom `server` resource in the Kubernetes cluster hosting Arges
 
 A flow of the registration process looks like:

--- a/examples/bootstrap/kustomization.yaml
+++ b/examples/bootstrap/kustomization.yaml
@@ -24,3 +24,10 @@ patchesJson6902:
       name: metal-metadata-server
       namespace: arges-system
     path: metadata_patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: metal-controller-manager
+      namespace: arges-system
+    path: api_endpoint.yaml

--- a/examples/mgmt/kustomization.yaml
+++ b/examples/mgmt/kustomization.yaml
@@ -6,13 +6,6 @@ resources:
   - environments.yaml
 patchesJson6902:
   - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: metal-controller-manager
-      namespace: arges-system
-    path: discovery_kubeconfig_patch.yaml
-  - target:
       group: metal.arges.dev
       version: v1alpha1
       kind: Environment


### PR DESCRIPTION
This brings in a new version of mcm that removes the requirements for a
discovery kubeconfig.